### PR TITLE
use portal_state to access the portal and read the registry

### DIFF
--- a/src/collective/multitheme/theme/manifest.cfg
+++ b/src/collective/multitheme/theme/manifest.cfg
@@ -12,14 +12,14 @@ disabled-bundles =
 directory = template-overrides
 
 [theme:parameters]
-cssfile = python:context.portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.style']
-default = python:context.portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.rules']=='default'
-spot =    python:context.portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.rules']=='spot'
-head =    python:context.portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.rules']=='head'
-color1 =  python:str(context.portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.color1'])
-color2 =  python:context.portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.color2']
-color3 =  python:context.portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.color3']
-fullwidth= python:context.portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.fullwidth']==True
+cssfile = python:portal_state.portal().portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.style']
+default = python:portal_state.portal().portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.rules']=='default'
+spot =    python:portal_state.portal().portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.rules']=='spot'
+head =    python:portal_state.portal().portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.rules']=='head'
+color1 =  python:str(portal_state.portal().portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.color1'])
+color2 =  python:portal_state.portal().portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.color2']
+color3 =  python:portal_state.portal().portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.color3']
+fullwidth= python:portal_state.portal().portal_registry['collective.multitheme.interfaces.ICollectiveMultiThemeSettings.fullwidth']==True
 ajax_load = python:request.form.get('ajax_load')
 
 [theme:themefragments:tiles]


### PR DESCRIPTION
a possible bug in Plone 5.2.1 loads the wrong context